### PR TITLE
Add more sacred components

### DIFF
--- a/packages/design-system/sacred/components/ActionBar.tsx
+++ b/packages/design-system/sacred/components/ActionBar.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { ButtonGroup } from './ButtonGroup';
+import { cn } from '../../lib/utils';
+
+export interface ActionBarItem {
+  hotkey?: React.ReactNode;
+  onClick?: () => void;
+  openHotkey?: string;
+  selected?: boolean;
+  body: React.ReactNode;
+  items?: any;
+}
+
+export interface ActionBarProps {
+  items: ActionBarItem[];
+  className?: string;
+}
+
+export const ActionBar: React.FC<ActionBarProps> = ({ items, className }) => (
+  <div className={cn('bg-background shadow-inner shadow-border', className)}>
+    <ButtonGroup items={items} />
+  </div>
+);

--- a/packages/design-system/sacred/components/ActionButton.tsx
+++ b/packages/design-system/sacred/components/ActionButton.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+interface ActionButtonProps {
+  onClick?: () => void;
+  hotkey?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+  isSelected?: boolean;
+}
+
+export const ActionButton = React.forwardRef<HTMLDivElement, ActionButtonProps>(
+  ({ onClick, hotkey, children, className, isSelected }, ref) => (
+    <div
+      ref={ref}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center justify-between font-mono text-base select-none',
+        'cursor-pointer outline-none',
+        'hover:[&_.hotkey]:bg-primary hover:[&_.content]:shadow-inner hover:[&_.content]:shadow-primary',
+        'focus:[&_.hotkey]:bg-primary focus:[&_.content]:shadow-inner focus:[&_.content]:shadow-primary',
+        isSelected && '[&_.content]:bg-primary',
+        className,
+      )}
+    >
+      {hotkey ? (
+        <span className="hotkey bg-muted text-foreground px-1">{hotkey}</span>
+      ) : null}
+      <span className="content bg-background shadow-inner shadow-muted px-1 uppercase">
+        {children}
+      </span>
+    </div>
+  ),
+);
+
+ActionButton.displayName = 'ActionButton';

--- a/packages/design-system/sacred/components/ActionListItem.tsx
+++ b/packages/design-system/sacred/components/ActionListItem.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface ActionListItemProps {
+  style?: React.CSSProperties;
+  icon?: React.ReactNode;
+  children?: React.ReactNode;
+  href?: string;
+  target?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement | HTMLAnchorElement>;
+}
+
+export const ActionListItem: React.FC<ActionListItemProps> = ({
+  href,
+  target,
+  onClick,
+  children,
+  icon,
+  style,
+}) => {
+  const classes = cn('flex items-start justify-between cursor-pointer');
+  const content = (
+    <>
+      <figure className="icon flex h-6 w-6 items-center justify-center bg-foreground text-background mr-2">
+        {icon}
+      </figure>
+      <span className="flex-1 bg-background px-1">{children}</span>
+    </>
+  );
+  if (href) {
+    return (
+      <a href={href} target={target} className={classes} style={style} tabIndex={0} role="link">
+        {content}
+      </a>
+    );
+  }
+  return (
+    <div onClick={onClick} className={classes} style={style} tabIndex={0} role="button">
+      {content}
+    </div>
+  );
+};

--- a/packages/design-system/sacred/components/AlertBanner.tsx
+++ b/packages/design-system/sacred/components/AlertBanner.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface AlertBannerProps extends React.HTMLAttributes<HTMLDivElement> {
+  children?: React.ReactNode;
+}
+
+export const AlertBanner: React.FC<AlertBannerProps> = ({ children, className, style, ...rest }) => (
+  <div
+    className={cn(
+      'bg-border text-foreground shadow-[1ch_1ch_0_0_var(--theme-border-subdued)] p-2 font-medium',
+      className,
+    )}
+    style={style}
+    {...rest}
+  >
+    {children}
+  </div>
+);

--- a/packages/design-system/sacred/components/Avatar.tsx
+++ b/packages/design-system/sacred/components/Avatar.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  src?: string;
+  href?: string;
+  target?: string;
+  children?: React.ReactNode;
+}
+
+export const Avatar: React.FC<AvatarProps> = ({
+  src,
+  href,
+  target,
+  children,
+  className,
+  style,
+  ...rest
+}) => {
+  const backgroundStyle = src ? { backgroundImage: `url(${src})`, backgroundSize: 'cover' } : {};
+  const element = href ? (
+    <a
+      className={cn('inline-block w-8 h-8 bg-center bg-cover', className)}
+      style={{ ...style, ...backgroundStyle }}
+      href={href}
+      target={target}
+      tabIndex={0}
+      role="link"
+    />
+  ) : (
+    <figure
+      className={cn('inline-block w-8 h-8 bg-center bg-cover', className)}
+      style={{ ...style, ...backgroundStyle }}
+    />
+  );
+
+  if (!children) return element;
+
+  return (
+    <div className={cn('flex items-center gap-2', className)} {...rest} style={undefined}>
+      {element}
+      <span>{children}</span>
+    </div>
+  );
+};

--- a/packages/design-system/sacred/components/Badge.tsx
+++ b/packages/design-system/sacred/components/Badge.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  children?: React.ReactNode;
+}
+
+export const Badge: React.FC<BadgeProps> = ({ children, className, ...rest }) => (
+  <span
+    className={cn(
+      'inline-block bg-border text-foreground font-mono uppercase px-1 text-center',
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+  </span>
+);

--- a/packages/design-system/sacred/components/Button.tsx
+++ b/packages/design-system/sacred/components/Button.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  theme?: 'PRIMARY' | 'SECONDARY';
+  isDisabled?: boolean;
+  children?: React.ReactNode;
+}
+
+export const Button: React.FC<ButtonProps> = ({
+  theme = 'PRIMARY',
+  isDisabled,
+  children,
+  className,
+  ...rest
+}) => {
+  const base = 'inline-block w-full font-mono uppercase px-2 transition-all text-base';
+  const primary = 'bg-primary text-primary-foreground hover:bg-primary/80 focus:bg-primary/80';
+  const secondary =
+    'bg-background text-foreground shadow-inner shadow-border hover:bg-muted focus:bg-muted';
+  const disabled = 'bg-muted text-muted-foreground cursor-not-allowed';
+  const themeClass = theme === 'SECONDARY' ? secondary : primary;
+
+  if (isDisabled) {
+    return (
+      <div className={cn(base, themeClass, disabled, className)}>{children}</div>
+    );
+  }
+
+  return (
+    <button
+      className={cn(base, themeClass, className)}
+      disabled={isDisabled}
+      role="button"
+      tabIndex={0}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/design-system/sacred/components/ButtonGroup.tsx
+++ b/packages/design-system/sacred/components/ButtonGroup.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+import { ActionButton } from './ActionButton';
+
+interface ButtonGroupItem {
+  hotkey?: React.ReactNode;
+  openHotkey?: string;
+  onClick?: () => void;
+  body: React.ReactNode;
+  items?: any;
+  selected?: boolean;
+}
+
+interface ButtonGroupProps {
+  items?: ButtonGroupItem[];
+  isFull?: boolean;
+}
+
+export const ButtonGroup: React.FC<ButtonGroupProps> = ({ items, isFull }) => {
+  if (!items) return null;
+  return (
+    <div className={cn(isFull && 'grid grid-cols-3 gap-2')}>
+      {items.map((each) => (
+        <ActionButton key={String(each.body)} hotkey={each.hotkey} onClick={each.onClick} isSelected={each.selected}>
+          {each.body}
+        </ActionButton>
+      ))}
+    </div>
+  );
+};

--- a/packages/design-system/sacred/components/Divider.tsx
+++ b/packages/design-system/sacred/components/Divider.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface DividerProps extends React.HTMLAttributes<HTMLHRElement> {}
+
+export const Divider: React.FC<DividerProps> = ({ className, ...rest }) => (
+  <hr className={cn('border-border my-1', className)} {...rest} />
+);

--- a/packages/design-system/sacred/components/Input.tsx
+++ b/packages/design-system/sacred/components/Input.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  caretChars?: React.ReactNode;
+  label?: React.ReactNode;
+  isBlink?: boolean;
+}
+
+export function Input({
+  caretChars,
+  label,
+  isBlink = true,
+  placeholder,
+  onChange,
+  type,
+  id,
+  className,
+  ...rest
+}: InputProps) {
+  const generatedId = React.useId();
+  const inputId = id || generatedId;
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [text, setText] = React.useState(rest.defaultValue?.toString() || rest.value?.toString() || '');
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [selectionStart, setSelectionStart] = React.useState(text.length);
+
+  React.useEffect(() => {
+    if (rest.value !== undefined) {
+      const val = rest.value.toString();
+      setText(val);
+      setSelectionStart(val.length);
+    }
+  }, [rest.value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setText(value);
+    onChange?.(e);
+    setSelectionStart(e.target.selectionStart ?? value.length);
+  };
+
+  const handleFocus = () => setIsFocused(true);
+  const handleBlur = () => setIsFocused(false);
+  const handleSelect = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    const inputEl = e.currentTarget as HTMLInputElement;
+    setSelectionStart(inputEl.selectionStart ?? text.length);
+  };
+  const handleClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    const inputEl = e.currentTarget as HTMLInputElement;
+    inputEl.focus();
+    setSelectionStart(inputEl.selectionStart ?? text.length);
+  };
+
+  const isPlaceholderVisible = !text && placeholder;
+  const maskText = (t: string) => (type === 'password' ? '•'.repeat(t.length) : t);
+  const beforeCaretText = isPlaceholderVisible ? placeholder ?? '' : maskText(text.substring(0, selectionStart));
+  const afterCaretText = isPlaceholderVisible ? '' : maskText(text.substring(selectionStart));
+
+  return (
+    <div className={cn('relative', className)}>
+      {label && (
+        <label htmlFor={inputId} className="block bg-border px-1 text-foreground">
+          {label}
+        </label>
+      )}
+      <div className={cn('block', isFocused && 'ring-1 ring-primary')}>        
+        <div
+          className={cn(
+            'displayed overflow-hidden whitespace-nowrap pointer-events-none bg-background-input shadow-inner shadow-border',
+            isPlaceholderVisible && 'italic text-muted-foreground'
+          )}
+        >
+          {beforeCaretText}
+          {!isPlaceholderVisible && (
+            <span className={cn('block inline-block min-w-[1ch] bg-foreground text-background', isBlink && 'animate-pulse')}>{
+              caretChars || ''
+            }</span>
+          )}
+          {!isPlaceholderVisible && afterCaretText}
+        </div>
+        <input
+          id={inputId}
+          ref={inputRef}
+          className="absolute inset-0 w-full text-transparent caret-transparent outline-none bg-transparent"
+          value={text}
+          aria-placeholder={placeholder}
+          type={type}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onSelect={handleSelect}
+          onClick={handleClick}
+          {...rest}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/design-system/sacred/components/ModalStack.tsx
+++ b/packages/design-system/sacred/components/ModalStack.tsx
@@ -1,0 +1,29 @@
+'use client';
+import * as React from 'react';
+import { useModals } from './page/ModalContext';
+import { cn } from '../../lib/utils';
+
+export const ModalStack: React.FC = () => {
+  const { modalStack } = useModals();
+  const total = modalStack.length;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-50">
+      {modalStack.map((modal, index) => {
+        const offset = total - 1 - index;
+        const translateY = -offset * 40;
+        const blur = offset * 1.1;
+        const ModalComponent = modal.component as React.ComponentType<any>;
+        return (
+          <div
+            key={modal.key}
+            className="absolute pointer-events-auto transition-opacity transition-transform"
+            style={{ zIndex: 10 + index, transform: `translateY(${translateY}px)`, filter: `blur(${blur}px)` }}
+          >
+            <ModalComponent {...modal.props} />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/design-system/sacred/components/ModalTrigger.tsx
+++ b/packages/design-system/sacred/components/ModalTrigger.tsx
@@ -1,0 +1,19 @@
+'use client';
+import * as React from 'react';
+import { useModals } from './page/ModalContext';
+
+interface ModalTriggerProps {
+  children: React.ReactElement<{ onClick?: React.MouseEventHandler }>;
+  modal: React.ComponentType<any>;
+  modalProps?: Record<string, any>;
+}
+
+export const ModalTrigger: React.FC<ModalTriggerProps> = ({ children, modal, modalProps = {} }) => {
+  const { open } = useModals();
+  const onHandleOpenModal = () => {
+    open(modal, modalProps);
+  };
+  return React.cloneElement(children, {
+    onClick: onHandleOpenModal,
+  });
+};

--- a/packages/design-system/sacred/components/Row.tsx
+++ b/packages/design-system/sacred/components/Row.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
+  spacing?: 'between' | 'around';
+}
+
+export const Row: React.FC<RowProps> = ({ spacing, className, children, ...rest }) => (
+  <div
+    className={cn(
+      'flex items-center',
+      spacing === 'between' && 'justify-between',
+      spacing === 'around' && 'justify-around',
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+  </div>
+);

--- a/packages/design-system/sacred/components/Tooltip.tsx
+++ b/packages/design-system/sacred/components/Tooltip.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+export interface TooltipProps {
+  text: string;
+  children: React.ReactNode;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ text, children }) => (
+  <div className="relative group inline-block">
+    {children}
+    <span className="absolute left-1/2 top-full mt-1 -translate-x-1/2 scale-0 bg-foreground text-background px-2 py-1 text-xs group-hover:scale-100 transition-transform">
+      {text}
+    </span>
+  </div>
+);

--- a/packages/design-system/sacred/components/page/DefaultActionBar.tsx
+++ b/packages/design-system/sacred/components/page/DefaultActionBar.tsx
@@ -1,0 +1,21 @@
+'use client';
+import * as React from 'react';
+import { ButtonGroup } from '../ButtonGroup';
+import { cn } from '../../../lib/utils';
+
+interface DefaultActionBarItem {
+  hotkey: string;
+  onClick: () => void;
+  body: React.ReactNode;
+  items?: any;
+}
+
+interface DefaultActionBarProps {
+  items?: DefaultActionBarItem[];
+}
+
+export const DefaultActionBar: React.FC<DefaultActionBarProps> = ({ items = [] }) => (
+  <div className={cn('bg-background shadow-inner shadow-border')}>
+    <ButtonGroup items={items} isFull />
+  </div>
+);

--- a/packages/design-system/sacred/components/page/DefaultLayout.tsx
+++ b/packages/design-system/sacred/components/page/DefaultLayout.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+interface DefaultLayoutProps {
+  previewPixelSRC: string;
+  children?: React.ReactNode;
+}
+
+export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ previewPixelSRC, children }) => (
+  <div className={cn('relative')}> 
+    <img className="absolute inset-0 w-full h-full object-cover" src={previewPixelSRC} alt="" />
+    {children}
+  </div>
+);

--- a/packages/design-system/sacred/components/page/ModalContext.tsx
+++ b/packages/design-system/sacred/components/page/ModalContext.tsx
@@ -1,0 +1,43 @@
+'use client';
+import * as React from 'react';
+
+export type ModalComponent<P = {}> = React.ComponentType<React.PropsWithoutRef<P>>;
+
+export interface ModalState<P = any> {
+  key: string;
+  component: ModalComponent<P>;
+  props: P;
+}
+
+interface ModalContextType {
+  modalStack: ModalState[];
+  open: <P>(component: ModalComponent<P>, props: P) => string;
+  close: (key?: string) => void;
+}
+
+const ModalContext = React.createContext<ModalContextType | null>(null);
+
+export const ModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [modalStack, setModalStack] = React.useState<ModalState<any>[]>([]);
+
+  const open = <P,>(component: ModalComponent<P>, props: P): string => {
+    const key = `modal-${Date.now()}-${Math.random()}`;
+    const newModal: ModalState<P> = { key, component, props };
+    setModalStack((prev) => [...prev, newModal as ModalState<any>]);
+    return key;
+  };
+
+  const close = (key?: string): void => {
+    setModalStack((prev) => (key ? prev.filter((modal) => modal.key !== key) : prev.slice(0, -1)));
+  };
+
+  return <ModalContext.Provider value={{ modalStack, open, close }}>{children}</ModalContext.Provider>;
+};
+
+export const useModals = (): ModalContextType => {
+  const context = React.useContext(ModalContext);
+  if (!context) {
+    throw new Error('useModals must be used within a ModalProvider and use client');
+  }
+  return context;
+};

--- a/packages/design-system/sacred/index.ts
+++ b/packages/design-system/sacred/index.ts
@@ -1,0 +1,17 @@
+export { ActionButton } from './components/ActionButton';
+export { Input } from './components/Input';
+export { Avatar } from './components/Avatar';
+export { Badge } from './components/Badge';
+export { Button } from './components/Button';
+export { ButtonGroup } from './components/ButtonGroup';
+export { ActionBar } from './components/ActionBar';
+export { ActionListItem } from './components/ActionListItem';
+export { AlertBanner } from './components/AlertBanner';
+export { Divider } from './components/Divider';
+export { Row } from './components/Row';
+export { Tooltip } from './components/Tooltip';
+export { ModalStack } from './components/ModalStack';
+export { ModalTrigger } from './components/ModalTrigger';
+export { DefaultLayout } from './components/page/DefaultLayout';
+export { DefaultActionBar } from './components/page/DefaultActionBar';
+export { ModalProvider, useModals } from './components/page/ModalContext';

--- a/packages/design-system/sacred/sacred.css
+++ b/packages/design-system/sacred/sacred.css
@@ -1,0 +1,29 @@
+@import "../styles/globals.css";
+
+:root {
+  --theme-overlay: rgba(0,0,0,0.4);
+  --theme-background: var(--color-blue-80, #002d9c);
+  --theme-background-input: var(--color-blue-60, #0f62fe);
+  --theme-border: var(--color-blue-70, #0043ce);
+  --theme-text: var(--color-blue-10, #edf5ff);
+  --theme-button-foreground: var(--color-blue-60, #0f62fe);
+  --theme-button-background: var(--color-blue-70, #0043ce);
+  --theme-focused-foreground: var(--color-blue-50, #4589ff);
+  --font-family-mono: 'GeistMono-Regular', monospace;
+  --font-size: 16px;
+  --theme-line-height-base: 1.25;
+}
+
+/* Basic styling for sacred components */
+.displayed {
+  @apply overflow-hidden whitespace-nowrap pointer-events-none bg-background-input shadow-inner shadow-border;
+}
+
+/* ActionListItem styles */
+.icon {
+  @apply bg-foreground text-background flex items-center justify-center w-6 h-6 mr-2;
+}
+.text {
+  @apply bg-background flex-1 px-1;
+}
+


### PR DESCRIPTION
## Summary
- expand the sacred component sandbox with additional UI elements
- ported Avatar, Badge, Button, ButtonGroup, ActionBar, ActionListItem and more
- added basic modal support via ModalContext, ModalStack and ModalTrigger
- updated `sacred.css` with extra sample styles

## Testing
- `git status --short`