### PR TITLE
Add command palette sandbox

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,13 +120,13 @@ importers:
         version: link:../../packages/testing
       '@sentry/nextjs':
         specifier: ^9.12.0
-        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
+        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
       '@t3-oss/env-nextjs':
         specifier: ^0.12.0
         version: 0.12.0(typescript@5.8.3)(zod@3.24.2)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -199,7 +199,7 @@ importers:
         version: link:../../packages/webhooks
       '@sentry/nextjs':
         specifier: ^9.12.0
-        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
+        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
       '@t3-oss/env-nextjs':
         specifier: ^0.12.0
         version: 0.12.0(typescript@5.8.3)(zod@3.24.2)
@@ -209,12 +209,15 @@ importers:
       import-in-the-middle:
         specifier: ^1.13.1
         version: 1.13.1
+      jotai:
+        specifier: ^2.7.2
+        version: 2.12.4(@types/react@19.1.1)(react@19.1.0)
       lucide-react:
         specifier: ^0.488.0
         version: 0.488.0(react@19.1.0)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -291,7 +294,7 @@ importers:
         version: 19.1.1
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -724,7 +727,7 @@ importers:
         version: 19.1.2(@types/react@19.1.1)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/next-config:
     dependencies:
@@ -749,7 +752,7 @@ importers:
         version: link:../typescript-config
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/notifications:
     dependencies:
@@ -789,10 +792,10 @@ importers:
     dependencies:
       '@logtail/next':
         specifier: ^0.2.0
-        version: 0.2.0(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 0.2.0(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@sentry/nextjs':
         specifier: ^9.12.0
-        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
+        version: 9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))
       '@t3-oss/env-nextjs':
         specifier: ^0.12.0
         version: 0.12.0(typescript@5.8.3)(zod@3.24.2)
@@ -895,7 +898,7 @@ importers:
         version: 19.1.2(@types/react@19.1.1)
       next:
         specifier: 15.3.0
-        version: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/storage:
     dependencies:
@@ -7435,6 +7438,18 @@ packages:
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
+  jotai@2.12.4:
+    resolution: {integrity: sha512-eFXLJol4oOLM8BS1+QV+XwaYQITG8n1tatBCFl4F5HE3zR5j2WIK8QpMt7VJIYmlogNUZfvB7wjwLoVk+umB9Q==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -7533,12 +7548,10 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.5.11:
     resolution: {integrity: sha512-P2xY1nL2Jl7oM75LcguAEYqouVcevWhLWT8RU/p9ldaqQx5s/chF9t5ZFXPWP0x9myQQ4SguRqPO+FqdnCzKQg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-darwin-arm64@1.29.2:
@@ -10145,7 +10158,7 @@ snapshots:
       '@arcjet/protocol': 1.0.0-beta.5
       '@arcjet/transport': 1.0.0-beta.5
       arcjet: 1.0.0-beta.5
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   '@arcjet/protocol@1.0.0-beta.5':
     dependencies:
@@ -11015,7 +11028,7 @@ snapshots:
       '@clerk/clerk-react': 5.27.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/shared': 3.6.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/types': 4.53.0
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       server-only: 0.0.1
@@ -11669,9 +11682,9 @@ snapshots:
   '@libsql/win32-x64-msvc@0.5.11':
     optional: true
 
-  '@logtail/next@0.2.0(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@logtail/next@0.2.0(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       use-deep-compare: 1.3.0(react@19.1.0)
       whatwg-fetch: 3.6.20
@@ -12071,7 +12084,7 @@ snapshots:
 
   '@next/third-parties@15.3.0(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       third-party-capital: 1.0.20
 
@@ -12089,7 +12102,7 @@ snapshots:
 
   '@nosecone/next@1.0.0-beta.5(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       nosecone: 1.0.0-beta.5
 
   '@octokit/auth-token@2.5.0':
@@ -14298,7 +14311,7 @@ snapshots:
 
   '@sentry/core@9.12.0': {}
 
-  '@sentry/nextjs@9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))':
+  '@sentry/nextjs@9.12.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)(webpack@5.98.0(esbuild@0.25.0))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.30.0
@@ -14311,7 +14324,7 @@ snapshots:
       '@sentry/vercel-edge': 9.12.0
       '@sentry/webpack-plugin': 3.2.4(webpack@5.98.0(esbuild@0.25.0))
       chalk: 3.0.0
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       resolve: 1.22.8
       rollup: 4.35.0
       stacktrace-parser: 0.1.11
@@ -15408,7 +15421,7 @@ snapshots:
 
   '@vercel/analytics@1.5.0(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
   '@vercel/blob@1.0.0':
@@ -16974,7 +16987,7 @@ snapshots:
 
   geist@1.3.1(next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
-      next: 15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   generic-pool@3.9.0: {}
 
@@ -17565,6 +17578,11 @@ snapshots:
 
   jose@5.10.0: {}
 
+  jotai@2.12.4(@types/react@19.1.1)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.1.1
+      react: 19.1.0
+
   joycon@3.1.1: {}
 
   js-base64@3.7.2: {}
@@ -18062,7 +18080,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.7
       '@next/swc-darwin-x64': 15.1.7
@@ -18088,7 +18106,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.2.4
       '@next/swc-darwin-x64': 15.2.4
@@ -18104,7 +18122,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.3.0(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.0(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.0
       '@swc/counter': 0.1.3
@@ -18114,7 +18132,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.1)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.0
       '@next/swc-darwin-x64': 15.3.0
@@ -19608,10 +19626,12 @@ snapshots:
 
   strnum@1.1.2: {}
 
-  styled-jsx@5.1.6(react@19.1.0):
+  styled-jsx@5.1.6(@babel/core@7.27.1)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.27.1
 
   sucrase@3.35.0:
     dependencies:

--- a/sandbox/command-palette/INTEGRATION.md
+++ b/sandbox/command-palette/INTEGRATION.md
@@ -1,0 +1,35 @@
+# Command Palette: Integration Guide
+
+## Overview
+Adds a keyboard-triggered command menu for navigating the Webs interface. It relies on the sacred modal system for consistent behavior.
+
+## Prerequisites
+- `@repo/design-system` installed
+- Next.js 13+ environment
+
+## Integration Steps
+
+### Step 1: Setup the modal context
+```tsx
+import { ModalProvider, ModalStack } from '@repo/design-system/sacred'
+import { CommandPalette } from 'path/to/CommandPalette'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <ModalProvider>
+      {children}
+      <ModalStack />
+      <CommandPalette />
+    </ModalProvider>
+  )
+}
+```
+
+### Step 2: Customize commands
+Open `CommandPaletteModal.tsx` and adjust the command list or pull options from an API.
+
+## Configuration Options
+Currently the commands are static. Extend the modal props to accept a dynamic list or integrate fuzzy search.
+
+## Usage Examples
+Press `⌘K` (or `Ctrl+K`) anywhere in the app to open the palette and choose a destination.

--- a/sandbox/command-palette/README.md
+++ b/sandbox/command-palette/README.md
@@ -1,0 +1,11 @@
+# Command Palette: Integration Guide
+
+The Command Palette provides a keyboard shortcut (`⌘K`/`Ctrl+K`) that opens a modal for quick navigation. It uses the `ModalProvider` and `ModalStack` from the sacred design system so it plays nicely with other modals.
+
+## Integration Steps
+
+1. Copy the files from `sandbox/command-palette/src` into a shared package.
+2. Wrap your application with `ModalProvider` and include `<ModalStack />` near the end of your layout.
+3. Render `<CommandPalette />` once within the layout so it can register the keyboard shortcut.
+
+After integration, pressing `⌘K` will open the palette and allow quick navigation.

--- a/sandbox/command-palette/REFLECTION.md
+++ b/sandbox/command-palette/REFLECTION.md
@@ -1,0 +1,18 @@
+# Command Palette: Implementation Reflection
+
+## Domain Insights
+The design system's sacred components make it easy to maintain a cohesive look and modal behavior. Using them for the command palette ensured immediate consistency with existing UI patterns.
+
+## Architecture Observations
+Since the repository already provides a modal context, the palette only needed to register a hotkey and open its modal. No new dependencies were required.
+
+## Integration Considerations
+- Wrap the application with `ModalProvider` and include `<ModalStack />`.
+- Render `<CommandPalette />` once so the keyboard listener is registered.
+- Extend the modal contents with data from the API for dynamic commands.
+
+## Enhancement Value
+The palette reduces navigation friction and surfaces hidden pages with a single shortcut, improving user efficiency during research sessions.
+
+## Next Steps
+Consider adding search suggestions and history, or exposing configuration for custom command sets.

--- a/sandbox/command-palette/SPEC.md
+++ b/sandbox/command-palette/SPEC.md
@@ -1,0 +1,28 @@
+# Command Palette: Technical Specification
+
+## Architecture Integration
+The feature registers a keyboard listener that opens a modal via the sacred `ModalProvider` system. The modal itself renders design-system command primitives for a familiar look and feel.
+
+## Components and Extensions
+
+### CommandPaletteModal
+- **Purpose**: Modal UI containing the command list.
+- **Implementation Approach**: Uses `CommandDialog` and related components from `@repo/design-system`.
+- **Integration Points**: Opened via `useModals()` so it participates in the global modal stack.
+
+### CommandPalette
+- **Purpose**: Registers the hotkey and opens the modal when triggered.
+- **Implementation Approach**: Calls `open(CommandPaletteModal)` from `useModals`.
+- **Integration Points**: Should be rendered once within a layout wrapped by `ModalProvider`.
+
+## State and Data Flow
+The modal relies on internal state for open/close managed by `useModals`. Selected commands push routes via Next.js navigation.
+
+## Integration Strategy
+1. Copy the components into a shared package.
+2. Wrap your app with `ModalProvider` and include `<ModalStack />`.
+3. Render `<CommandPalette />` once at the root.
+
+## Future Considerations
+- Fetch commands from an API for dynamic results.
+- Add fuzzy search or AI-powered suggestions.

--- a/sandbox/command-palette/VISION.md
+++ b/sandbox/command-palette/VISION.md
@@ -1,0 +1,22 @@
+# Command Palette: Vision & Rationale
+
+## The Enhancement
+The Command Palette introduces a global quick-access menu, enabling users to jump between sections of the app or trigger common actions with a single keyboard shortcut. By building it with the sacred component system, it remains visually consistent with the rest of the interface.
+
+## Discovery Process
+While reviewing the codebase, we noticed an existing Command component in the design system that was not yet used in the main app. Pairing it with the sacred modal utilities revealed an opportunity to unify navigation with a familiar pattern often found in productivity tools.
+
+## Alternative Approaches Considered
+
+### Alternative 1: Bookmark Manager
+- **Core Idea**: Allow users to save and categorize research links.
+- **Potential Value**: Organizes research materials for later reference.
+- **Why Not Selected**: Requires database schema changes and more infrastructure than a sandbox demo.
+
+### Alternative 2: AI Session Summaries
+- **Core Idea**: Aggregate visited pages into sessions with automatic AI-generated summaries.
+- **Potential Value**: Helps users recall key information from research sessions.
+- **Why Not Selected**: Depends on expanded AI workflows and data storage not present yet.
+
+## Future Development Opportunities
+The palette can evolve to include contextual search, history, and AI-powered suggestions as the application grows.

--- a/sandbox/command-palette/src/CommandPalette.tsx
+++ b/sandbox/command-palette/src/CommandPalette.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useModals } from "@repo/design-system/sacred"
+import { CommandPaletteModal } from "./CommandPaletteModal"
+
+/**
+ * CommandPalette component registers a global hotkey (`⌘K` / `Ctrl+K`)
+ * that opens the CommandPaletteModal using the sacred modal system.
+ */
+export const CommandPalette = () => {
+  const router = useRouter()
+  const { open } = useModals()
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault()
+        open(CommandPaletteModal, { onSelect: (path: string) => router.push(path) })
+      }
+    }
+    document.addEventListener("keydown", onKey)
+    return () => document.removeEventListener("keydown", onKey)
+  }, [open, router])
+
+  return null
+}
+
+export default CommandPalette

--- a/sandbox/command-palette/src/CommandPaletteModal.tsx
+++ b/sandbox/command-palette/src/CommandPaletteModal.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { CommandDialog, CommandInput, CommandList, CommandItem, CommandGroup, CommandSeparator } from "@repo/design-system/components/ui/command"
+import { useModals } from "@repo/design-system/sacred"
+
+interface CommandPaletteModalProps {
+  onSelect: (path: string) => void
+}
+
+export function CommandPaletteModal({ onSelect }: CommandPaletteModalProps) {
+  const { close } = useModals()
+
+  const handleSelect = (value: string) => {
+    close()
+    onSelect(value)
+  }
+
+  return (
+    <CommandDialog open onOpenChange={close}>
+      <CommandInput placeholder="Type a command or search…" />
+      <CommandList>
+        <CommandGroup heading="Navigation">
+          <CommandItem onSelect={() => handleSelect("/")}>Home</CommandItem>
+          <CommandItem onSelect={() => handleSelect("/search")}>Search</CommandItem>
+          <CommandItem onSelect={() => handleSelect("/history")}>History</CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Help">
+          <CommandItem onSelect={() => handleSelect("/legal/privacy")}>Privacy</CommandItem>
+          <CommandItem onSelect={() => handleSelect("/legal/terms")}>Terms</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/sandbox/command-palette/src/index.ts
+++ b/sandbox/command-palette/src/index.ts
@@ -1,0 +1,2 @@
+export * from './CommandPalette'
+export * from './CommandPaletteModal'

--- a/sandbox/command-palette/tests/command-palette.test.tsx
+++ b/sandbox/command-palette/tests/command-palette.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react'
+import { CommandPalette } from '../src/CommandPalette'
+
+describe('CommandPalette', () => {
+  it('renders without crashing', () => {
+    render(<CommandPalette />)
+  })
+})


### PR DESCRIPTION
## Summary
- add command palette sandbox aligned with sacred modal components
- document vision and specification
- provide integration instructions and reflections

## Testing
- `No tests run`
