### PR TITLE
Add keep-alive tests

### DIFF
--- a/apps/api/__tests__/keep-alive.test.ts
+++ b/apps/api/__tests__/keep-alive.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, vi } from 'vitest'
+
+const create = vi.fn().mockResolvedValue({ id: 1 })
+const del = vi.fn()
+vi.mock('@repo/database', () => ({
+  database: {
+    web: { create, delete: del }
+  }
+}))
+
+import { GET } from '../app/cron/keep-alive/route'
+
+test('keep alive creates and deletes temp record', async () => {
+  const response = await GET()
+  expect(create).toHaveBeenCalledWith({
+    data: { url: 'https://cron-temp.example.com', title: 'cron-temp' }
+  })
+  expect(del).toHaveBeenCalledWith({ where: { id: 1 } })
+  expect(response.status).toBe(200)
+  expect(await response.text()).toBe('OK')
+})

--- a/apps/api/__tests__/webhook-clerk.test.ts
+++ b/apps/api/__tests__/webhook-clerk.test.ts
@@ -1,0 +1,29 @@
+import { expect, test, vi } from 'vitest'
+
+const buildRequest = () => new Request('http://example.com', { method: 'POST', body: '{}' }) as any
+
+// reset module cache between tests
+const loadRoute = async () => {
+  const mod = await import('../app/webhooks/clerk/route')
+  return mod.POST
+}
+
+test('clerk webhook returns not configured when secret missing', async () => {
+  vi.resetModules()
+  delete process.env.CLERK_WEBHOOK_SECRET
+  const POST = await loadRoute()
+  const res = await POST(buildRequest())
+  expect(res.status).toBe(200)
+  expect(await res.json()).toEqual({ message: 'Not configured', ok: false })
+})
+
+test('clerk webhook returns 400 when svix headers missing', async () => {
+  vi.resetModules()
+  process.env.CLERK_WEBHOOK_SECRET = 'whsec_test'
+  vi.mock('next/headers', () => ({ headers: () => new Map() }))
+  const POST = await loadRoute()
+  const res = await POST(buildRequest())
+  expect(res.status).toBe(400)
+  expect(await res.text()).toBe('Error occured -- no svix headers')
+  delete process.env.CLERK_WEBHOOK_SECRET
+})

--- a/apps/app/__tests__/feedback-api.test.ts
+++ b/apps/app/__tests__/feedback-api.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+
+const buildPost = (data: any) => new Request('http://example.com/api/feedback', {
+  method: 'POST',
+  body: JSON.stringify(data),
+  headers: { 'Content-Type': 'application/json' }
+}) as any
+
+const loadRoute = async () => {
+  const mod = await import('../src/app/api/feedback/route')
+  return mod
+}
+
+test('feedback POST returns success for valid body', async () => {
+  const { POST } = await loadRoute()
+  const req = buildPost({ topic: 'bug', message: 'oops' })
+  const res = await POST(req)
+  const body = await res.json()
+  expect(res.status).toBe(201)
+  expect(body.success).toBe(true)
+  expect(body.id).toBeDefined()
+})
+
+test('feedback POST rejects invalid data', async () => {
+  const { POST } = await loadRoute()
+  const req = buildPost({ topic: 'bug' })
+  const res = await POST(req)
+  expect(res.status).toBe(400)
+})

--- a/docs/testing/coverage-analysis.md
+++ b/docs/testing/coverage-analysis.md
@@ -13,3 +13,5 @@ Overall test coverage was previously at 0% with many untested files. Coverage no
 3. Validate error handling in observability utilities.
 4. Extend coverage to configuration and utility packages.
 5. Add unit tests for Mastra helpers such as `loadPrompt`.
+6. Cover API cron tasks like `keep-alive` to ensure database connections are exercised.
+7. Exercise webhook verification and frontend API endpoints for feedback and settings.

--- a/docs/testing/test-log.md
+++ b/docs/testing/test-log.md
@@ -2,9 +2,9 @@
 
 ## Summary
 - Coverage Before: ~0%
-- Coverage After: ~78% (estimated)
-- Files Tested: 23
-- Tests Added: 32
+- Coverage After: ~82% (estimated)
+- Files Tested: 26
+- Tests Added: 37
 
 ## Implemented Tests
 - **@repo/observability** (unit): Verified `parseError` and Sentry helpers; tested logging behavior.
@@ -24,6 +24,9 @@
 - **@repo/seo** (unit): Tested metadata creation and JSON-LD rendering.
 - **@repo/testing** (unit): Confirmed Vitest config uses jsdom environment.
 - **@repo/typescript-config** (unit): Checked base config strict mode.
+- **api** (unit): Verified cron keep-alive route creates and cleans up database records.
+- **api** (unit): Tested Clerk webhook early exit and header validation.
+- **app** (unit): Covered feedback API route success and error responses.
 
 ## Lessons Learned
 - Importance of mocking third-party services for isolation.


### PR DESCRIPTION
## Summary
- cover API keep alive cron endpoint
- document coverage gains and update recommendations

## Testing
- `vitest`