### PR TITLE
Refactor API services and responses

### DIFF
--- a/apps/app/src/app/api/feedback/route.ts
+++ b/apps/app/src/app/api/feedback/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { createFeedback, listFeedback } from '@/lib/api/services/feedback';
+import { success, created, error as errorResponse } from '@/lib/api/response';
 
 export async function POST(request: NextRequest) {
   try {
@@ -7,13 +8,10 @@ export async function POST(request: NextRequest) {
     const userAgent = request.headers.get('user-agent');
     const referer = request.headers.get('referer');
     const feedback = await createFeedback({ ...body, userAgent, url: referer });
-    return NextResponse.json(
-      { success: true, id: feedback.id, message: 'Feedback submitted successfully' },
-      { status: 201 },
-    );
+    return created({ id: feedback.id, message: 'Feedback submitted successfully' });
   } catch (error) {
     console.error('Error submitting feedback:', error);
-    return NextResponse.json({ error: 'Failed to submit feedback' }, { status: 500 });
+    return errorResponse('Failed to submit feedback');
   }
 }
 
@@ -25,9 +23,9 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get('limit') || '50');
     const offset = parseInt(searchParams.get('offset') || '0');
     const result = await listFeedback({ topic, status, limit, offset });
-    return NextResponse.json({ ...result, hasMore: offset + limit < result.total });
+    return success({ ...result, hasMore: offset + limit < result.total });
   } catch (error) {
     console.error('Error fetching feedback:', error);
-    return NextResponse.json({ error: 'Failed to fetch feedback' }, { status: 500 });
+    return errorResponse('Failed to fetch feedback');
   }
 }

--- a/apps/app/src/app/api/user-settings/route.ts
+++ b/apps/app/src/app/api/user-settings/route.ts
@@ -1,18 +1,19 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { auth } from '@repo/auth/server';
 import { getUserSettings, updateUserSettings } from '@/lib/api/services/userSettings';
+import { success, error as errorResponse } from '@/lib/api/response';
 
 export async function GET() {
   try {
     const { userId } = await auth();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return errorResponse('Unauthorized', 401);
     }
     const settings = await getUserSettings(userId);
-    return NextResponse.json(settings);
+    return success(settings);
   } catch (error) {
     console.error('Failed to fetch user settings:', error);
-    return NextResponse.json({ error: 'Failed to fetch settings' }, { status: 500 });
+    return errorResponse('Failed to fetch settings');
   }
 }
 
@@ -20,13 +21,13 @@ export async function PATCH(request: NextRequest) {
   try {
     const { userId } = await auth();
     if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      return errorResponse('Unauthorized', 401);
     }
     const body = await request.json();
     const settings = await updateUserSettings(userId, body);
-    return NextResponse.json(settings);
+    return success(settings);
   } catch (error) {
     console.error('Failed to update user settings:', error);
-    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
+    return errorResponse('Failed to update settings');
   }
 }

--- a/apps/app/src/app/api/webs/[id]/route.ts
+++ b/apps/app/src/app/api/webs/[id]/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { getWebById, updateWeb } from '@/lib/api/services/webs';
+import { success, error as errorResponse } from '@/lib/api/response';
 
 export async function GET(
   request: NextRequest,
@@ -9,12 +10,12 @@ export async function GET(
     const { id } = await params;
     const web = await getWebById(id);
     if (!web) {
-      return NextResponse.json({ error: 'Web not found' }, { status: 404 });
+      return errorResponse('Web not found', 404);
     }
-    return NextResponse.json(web);
+    return success(web);
   } catch (error) {
     console.error('Error fetching web:', error);
-    return NextResponse.json({ error: 'Failed to fetch web' }, { status: 500 });
+    return errorResponse('Failed to fetch web');
   }
 }
 
@@ -26,9 +27,9 @@ export async function PATCH(
     const { id } = await params;
     const updates = await request.json();
     const web = await updateWeb(id, updates);
-    return NextResponse.json(web);
+    return success(web);
   } catch (error) {
     console.error('Error updating web:', error);
-    return NextResponse.json({ error: 'Failed to update web' }, { status: 500 });
+    return errorResponse('Failed to update web');
   }
 }

--- a/apps/app/src/app/api/webs/route.ts
+++ b/apps/app/src/app/api/webs/route.ts
@@ -1,15 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { listWebs, createWeb } from '@/lib/api/services/webs';
+import { success, created, error as errorResponse } from '@/lib/api/response';
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const workspaceId = searchParams.get('workspaceId') || 'default';
     const webs = await listWebs(workspaceId);
-    return NextResponse.json(webs);
+    return success(webs);
   } catch (error) {
     console.error('Error fetching webs:', error);
-    return NextResponse.json({ error: 'Failed to fetch webs' }, { status: 500 });
+    return errorResponse('Failed to fetch webs');
   }
 }
 
@@ -17,9 +18,9 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const web = await createWeb(body);
-    return NextResponse.json(web, { status: 201 });
+    return created(web);
   } catch (error) {
     console.error('Error creating web:', error);
-    return NextResponse.json({ error: 'Failed to create web' }, { status: 500 });
+    return errorResponse('Failed to create web');
   }
 }

--- a/apps/app/src/lib/api/response.ts
+++ b/apps/app/src/lib/api/response.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+type SuccessResponse<T> = { success: true; data: T };
+type ErrorResponse = { success: false; message: string };
+
+export function success<T>(data: T, status = 200) {
+  return NextResponse.json<SuccessResponse<T>>(
+    { success: true, data },
+    { status },
+  );
+}
+
+export function created<T>(data: T) {
+  return success(data, 201);
+}
+
+export function error(message: string, status = 500) {
+  return NextResponse.json<ErrorResponse>(
+    { success: false, message },
+    { status },
+  );
+}

--- a/apps/app/src/lib/api/schemas/feedback.ts
+++ b/apps/app/src/lib/api/schemas/feedback.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const feedbackSchema = z.object({
+  topic: z.enum(['BUG', 'FEATURE', 'UI', 'PERFORMANCE', 'GENERAL']),
+  message: z.string(),
+  userAgent: z.string().nullable(),
+  url: z.string().url().nullable(),
+  userId: z.string().nullable(),
+  status: z.enum(['OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED']).optional(),
+});
+
+export type FeedbackInput = z.infer<typeof feedbackSchema>;

--- a/apps/app/src/lib/api/schemas/index.ts
+++ b/apps/app/src/lib/api/schemas/index.ts
@@ -1,2 +1,3 @@
 export * from './web';
 export * from './userSettings';
+export * from './feedback';

--- a/apps/app/src/lib/api/services/feedback.ts
+++ b/apps/app/src/lib/api/services/feedback.ts
@@ -1,16 +1,11 @@
 import { database } from '@repo/database';
-import { z } from 'zod';
+import { feedbackSchema, type FeedbackInput } from '../schemas/feedback';
 
-export const feedbackSchema = z.object({
-  topic: z.enum(['BUG', 'FEATURE', 'UI', 'PERFORMANCE', 'GENERAL']),
-  message: z.string(),
-  userAgent: z.string().nullable(),
-  url: z.string().url().nullable(),
-  userId: z.string().nullable(),
-  status: z.enum(['OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED']).optional(),
-});
-
-export type Feedback = z.infer<typeof feedbackSchema> & { id: string; createdAt: string; updatedAt: string };
+export type Feedback = FeedbackInput & {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+};
 
 export async function createFeedback(input: unknown): Promise<Feedback> {
   const data = feedbackSchema.parse(input);


### PR DESCRIPTION
## Summary
- move feedback schema to schemas folder
- add API response helpers for consistent NextResponse usage
- use new helpers in all API routes
- update service code to import new schema

## Testing
- `pnpm exec tsc -p apps/app/tsconfig.json --noEmit` *(fails: cannot find module './generated/client')*